### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <version.commons-beanutils>1.8.3</version.commons-beanutils>
         <version.commons-cli>1.2</version.commons-cli>
         <version.commons-codec>1.9</version.commons-codec>
-        <version.commons-collections>3.2.1</version.commons-collections>
+        <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-digester>1.8</version.commons-digester>
         <version.commons-configuration>1.6</version.commons-configuration>
         <version.commons-pool>1.6</version.commons-pool>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
